### PR TITLE
Fixed a small bug: /me being handled incorrectly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.avisenera</groupId>
 	<artifactId>minecraftbot</artifactId>
 	<packaging>jar</packaging>
-	<version>2.2.5</version>
+	<version>2.2.6</version>
 	<name>MinecraftBot</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/avisenera/minecraftbot/listeners/MainListener.java
+++ b/src/main/java/com/avisenera/minecraftbot/listeners/MainListener.java
@@ -62,7 +62,7 @@ public class MainListener extends MBListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event) {
         // The command /me can't be registered normally, so it's handled here instead
-        if (event.getMessage().toLowerCase().startsWith("/me")) {
+        if (event.getMessage().toLowerCase().startsWith("/me ")) {
             try {
                 MCMessage msg = new MCMessage();
                 msg.player = event.getPlayer();


### PR DESCRIPTION
Commands like /mem were leading to an empty/blank emote appearing in IRC, whilst things like /memory led to "\* PlayerName ory" in IRC.

This small change fixes that problem.
